### PR TITLE
resolves slash as division deprecation warning

### DIFF
--- a/src/sass/partials/_yiq.scss
+++ b/src/sass/partials/_yiq.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 /// Determines whether a given color is light or dark.
 /// The YIQ color space function gives weights each RGB value according to how sensitive they are to human eyesight.
 /// @param {Color} $color - The color to test
@@ -11,7 +13,7 @@
   $green: green($color);
   $blue: blue($color);
 
-  $yiq: (($red*299)+($green*587)+($blue*114))/1000;
+  $yiq: math.div(($red*299)+($green*587)+($blue*114), 1000);
 
   @if $yiq-debug { @debug $yiq, $threshold; }
 


### PR DESCRIPTION
Per https://sass-lang.com/documentation/breaking-changes/slash-div; incorporates recommended adjustment to use math.div.